### PR TITLE
fix: update messages PendingIntent to use FLAG_IMMUTABLE

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -259,7 +259,7 @@ public class Transaction {
                 sentIntent.putExtra("message_uri", messageUri == null ? "" : messageUri.toString());
                 sentIntent.putExtra(SENT_SMS_BUNDLE, sentMessageParcelable);
                 PendingIntent sentPI = PendingIntent.getBroadcast(
-                        context, messageId, sentIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, messageId, sentIntent, PendingIntent.FLAG_IMMUTABLE);
 
                 Intent deliveredIntent;
                 if (explicitDeliveredSmsReceiver == null) {
@@ -272,7 +272,7 @@ public class Transaction {
                 deliveredIntent.putExtra("message_uri", messageUri == null ? "" : messageUri.toString());
                 deliveredIntent.putExtra(DELIVERED_SMS_BUNDLE, deliveredParcelable);
                 PendingIntent deliveredPI = PendingIntent.getBroadcast(
-                        context, messageId, deliveredIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, messageId, deliveredIntent, PendingIntent.FLAG_IMMUTABLE);
 
                 ArrayList<PendingIntent> sPI = new ArrayList<PendingIntent>();
                 ArrayList<PendingIntent> dPI = new ArrayList<PendingIntent>();
@@ -659,7 +659,7 @@ public class Transaction {
             intent.putExtra(MmsSentReceiver.EXTRA_CONTENT_URI, messageUri.toString());
             intent.putExtra(MmsSentReceiver.EXTRA_FILE_PATH, mSendFile.getPath());
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                    context, 0, intent, PendingIntent.FLAG_IMMUTABLE);
 
             Uri writerUri = (new Uri.Builder())
                     .authority(context.getPackageName() + ".MmsFileProvider")


### PR DESCRIPTION
Fixes messages not sending in LP3. This error was appearing in logcat:


```
10-18 16:27:46.369  7500  7675 W System.err: java.lang.IllegalArgumentException: com.lightos: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
10-18 16:27:46.369  7500  7675 W System.err: Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
10-18 16:27:46.370  7500  7675 W System.err:    at android.app.PendingIntent.checkPendingIntent(PendingIntent.java:430)
10-18 16:27:46.370  7500  7675 W System.err:    at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:733)
10-18 16:27:46.370  7500  7675 W System.err:    at android.app.PendingIntent.getBroadcast(PendingIntent.java:720)
10-18 16:27:46.370  7500  7675 W System.err:    at com.klinker.android.send_message.Transaction.sendSmsMessage(Transaction.java:293)
10-18 16:27:46.370  7500  7675 W System.err:    at com.klinker.android.send_message.Transaction.sendNewMessage(Transaction.java:173)
10-18 16:27:46.370  7500  7675 W System.err:    at com.klinker.android.send_message.Transaction.sendNewMessage(Transaction.java:192)
10-18 16:27:46.370  7500  7675 W System.err:    at com.lightos.messages.LightOSMessagesModule.triggerSendSms(LightOSMessagesModule.java:770)
10-18 16:27:46.371  7500  7675 W System.err:    at com.lightos.messages.LightOSMessagesModule.sendSms(LightOSMessagesModule.java:392)
10-18 16:27:46.371  7500  7675 W System.err:    at com.lightos.messages.LightOSMessagesModule.sendMessage(LightOSMessagesModule.java:143)
```

This PR updates all `PendingIntent` instances in `Transaction` to use `FLAG_IMMUTABLE`. This was tested by making the same changes in the LP3 codebase - messages now send. However, they appear twice in the message list, @aconanlai says it might be that the intent is sent multiple times, or the message appears twice in the SQLite database