### PR TITLE
fix stale intents broadcast by new mms

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -667,7 +667,7 @@ public class Transaction {
             intent.putExtra(MmsSentReceiver.EXTRA_CONTENT_URI, messageUri.toString());
             intent.putExtra(MmsSentReceiver.EXTRA_FILE_PATH, mSendFile.getPath());
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                    context, 0, intent, PendingIntent.FLAG_IMMUTABLE);
+                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
             Uri writerUri = (new Uri.Builder())
                     .authority(context.getPackageName() + ".MmsFileProvider")


### PR DESCRIPTION
This should fix the "MMS stuck in 'sending...'" bug we've been seeing the last while.

![image](https://github.com/user-attachments/assets/5aaeb7ef-5fd0-442f-a383-5a84c77b4f31)

The logs were showing us receiving a stale intent (stale message id) when sending a new one in the same thread as the previously sent mms.

I don't fully understand the reasoning for the stale intent but my guess is that mms can be sent multipart, triggering multiple intents to be added to the stack. We unsub our listener after receiving the first. Then when we resub, we get the stale intent before the new one. (although we don't get it until the new intent is broadcast so maybe there's a different mechanism happening).

Adding this flag makes sure the stale intent gets flushed.
