### PR TITLE
Fix/mms stuck in sending

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,10 +16,10 @@ android {
       }
     }
 
-    compileSdkVersion 25
+    compileSdkVersion 34
     defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion 25
+        minSdkVersion 27
+        targetSdkVersion 27
     }
 
     lintOptions {
@@ -30,8 +30,8 @@ android {
 }
 
 dependencies {
-    lp2Implementation files('../../shared/framework_all.jar')
-    lp3Implementation files('../../shared/lp3_framework_all.jar')
+    lp2Implementation files('../../../../framework_all/lp2.jar')
+    lp3Implementation files('../../../../framework_all/lp3.jar')
     implementation 'com.klinkerapps:logger:1.0.3'
     implementation 'com.squareup.okhttp:okhttp:2.5.0'
     implementation 'com.squareup.okhttp:okhttp-urlconnection:2.5.0'
@@ -39,7 +39,7 @@ dependencies {
 
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) { task ->
-        def isLp3 = task.toString().indexOf("Lp3") != -1;
-        options.compilerArgs.add("-Xbootclasspath/p:${rootDir}/shared/${isLp3 ? 'lp3_' : ''}framework_all.jar")
+        def isLp3 = task.toString().indexOf("Lp3") != -1
+        options.compilerArgs.add("-Xbootclasspath/p:${rootDir}/../../framework_all/${isLp3 ? 'lp3' : 'lp2'}.jar")
     }
 }

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -667,7 +667,7 @@ public class Transaction {
             intent.putExtra(MmsSentReceiver.EXTRA_CONTENT_URI, messageUri.toString());
             intent.putExtra(MmsSentReceiver.EXTRA_FILE_PATH, mSendFile.getPath());
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                    context, 0, intent, PendingIntent.FLAG_IMMUTABLE);
+                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
             Uri writerUri = (new Uri.Builder())
                     .authority(context.getPackageName() + ".MmsFileProvider")


### PR DESCRIPTION
NOTE: this also includes Gus' changes to build.gradle since we haven't merged that into master yet

This should fix the "MMS stuck in 'sending...'" bug we've been seeing the last while.

![image](https://github.com/user-attachments/assets/5aaeb7ef-5fd0-442f-a383-5a84c77b4f31)

The logs were showing us receiving a stale intent (stale message id) when sending a new one in the same thread as the previously sent mms.

I don't fully understand the reasoning for the stale intent but my guess is that mms can be sent multipart, triggering multiple intents to be added to the stack. We unsub our listener after receiving the first. Then when we resub, we get the stale intent before the new one. (although we don't get it until the new intent is broadcast so maybe there's a different mechanism happening).

Adding this flag makes sure the stale intent gets flushed.